### PR TITLE
Fix transformation of arguments with a default value and no specified type

### DIFF
--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -25,6 +25,19 @@ proc bar(yo: string) {.async.} =
 
 waitFor bar("hi")
 
+expectOutput """
+12
+23
+13
+"""
+
+proc logThis(x = 1; y = x+1) {.async.} =
+  log x, y
+
+waitFor logThis()
+waitFor logThis(2)
+waitFor logThis(1, 3)
+
 # The following expectations are for 64 bit architectures
 when defined(gcDestructors):
   expectOutput """

--- a/yasync.nim
+++ b/yasync.nim
@@ -197,7 +197,9 @@ iterator arguments(formalParams: NimNode): tuple[idx: int, name, typ, default: N
   for i in 1 ..< formalParams.len:
     let pp = formalParams[i]
     for j in 0 .. pp.len - 3:
-      yield (iParam, pp[j], copyNimTree(stripSinkFromArgType(pp[^2])), pp[^1])
+      var t = copyNimTree(stripSinkFromArgType(pp[^2]))
+      if t.kind == nnkEmpty: t = newCall("typeof", pp[^1])
+      yield (iParam, pp[j], t, pp[^1])
       inc iParam
 
 template keepFromReordering[T](v: T) =


### PR DESCRIPTION
Example:

``` nim
import pkg/yasync

proc example(x = 0) {.async.} =
  discard
```

Did error with `Error: type mismatch: got 'int' for 'x' but expected 'ref object'`